### PR TITLE
handle non-standard format

### DIFF
--- a/ffprobe3/ffprobe.py
+++ b/ffprobe3/ffprobe.py
@@ -75,8 +75,9 @@ class FFStream:
 
     def __init__(self, data_lines):
         for a in data_lines:
-            (key, val) = a.strip().split('=')
-            self.__dict__[key] = val
+            kvPair = a.strip().split('=')
+            if len(kvPair) > 1 :
+                self.__dict__[kvPair[0]] = kvPair[1]
 
     def is_audio(self):
         """


### PR DESCRIPTION
I got a video file from **iPhone 6s**, which have some metadata break this library, if you look into line 58 to 67, there is a custom container [SIDE_DATA] which breaks the expected format.

With this change those non-parseable property will be ignored, but return whatever we have, rather than crash. 
```
[50]:u'DISPOSITION:clean_effects=0\n'
[51]:u'DISPOSITION:attached_pic=0\n'
[52]:u'DISPOSITION:timed_thumbnails=0\n'
[53]:u'TAG:rotate=180\n'
[54]:u'TAG:creation_time=2017-05-25T06:51:53.000000Z\n'
[55]:u'TAG:language=und\n'
[56]:u'TAG:handler_name=Core Media Data Handler\n'
[57]:u'TAG:encoder=H.264\n'
[58]:u'[SIDE_DATA]\n'
[59]:u'side_data_type=Display Matrix\n'
[60]:u'side_data_size=36\n'
[61]:u'displaymatrix=\n'
[62]:u'00000000:       -65536           0           0\n'
[63]:u'00000001:            0      -65536           0\n'
[64]:u'00000002:     83886080    47185920  1073741824\n'
[65]:u'\n'
[66]:u'rotation=-180\n'
[67]:u'[/SIDE_DATA]\n'
```